### PR TITLE
Proxy changes needed for "retry sendToDevice" test

### DIFF
--- a/src/proxy/Proxy.ts
+++ b/src/proxy/Proxy.ts
@@ -1,12 +1,16 @@
+import { WatchTimeoutError } from "./WatchTimeoutError";
 import httpProxy from "http-proxy";
+import http from "http";
 import zlib from "zlib";
 
 type ResponseModifier = (response: string) => string;
 
 export class Proxy {
-    private httpProxy: httpProxy;
+    private httpProxy: ReturnType<typeof httpProxy.createProxyServer>;
+    private httpSever: http.Server;
     private disabledEndpoints: string[] = [];
     private responseModifierMap: Map<string, ResponseModifier> = new Map();
+    private waitForMap: Map<string, () => void> = new Map();
     public targetURL: string;
     
     target(url: string) {
@@ -17,16 +21,31 @@ export class Proxy {
             throw new Error("Invalid URL provided to Proxy.target() method");
         }
         this.targetURL = url;
-        this.httpProxy = new httpProxy({ target: url, selfHandleResponse: true });
+        this.httpProxy = httpProxy.createProxyServer({ target: url, selfHandleResponse: true });
+        this.httpSever = http.createServer((req, res) => { this.httpServerHandle(req, res); });
         this.setupEvents();
         return this;
     }
 
+    private httpServerHandle(req: http.IncomingMessage, res: http.ServerResponse) {
+        const currentEndpoint = req.url;
+        this.resolveWaitIfNeeded(currentEndpoint);
+        const isEndpointBlocked = this.disabledEndpoints.some(endpoint => currentEndpoint.includes(endpoint));
+        if (isEndpointBlocked) {
+            console.log(`Current endpoint "${currentEndpoint}" is blocked ​🔴​`);
+            res.statusCode = 503;
+            res.end("Blocked");
+            return;
+        }
+        console.log(`Current endpoint "${currentEndpoint}" is not blocked 🟢`);
+        this.httpProxy.web(req, res); 
+    }
+
     listen(port: number) {
-        if (!this.httpProxy) {
+        if (!this.httpProxy || !this.httpSever) {
             throw new Error("You must call Proxy.target() before you can use listen()");
         }
-        this.httpProxy.listen(port);
+        this.httpSever.listen(port);
         return this;
     }
 
@@ -55,11 +74,28 @@ export class Proxy {
         return this;
     }
 
+    async waitForEndpoint(endpoint: string, timeout: number) {
+        // See if we're already tracking this endpoint
+        const existingPromise = this.waitForMap.get(endpoint);
+        if (existingPromise) {
+            return existingPromise;
+        }
+        const timeoutPromise = new Promise((_, rej) => {
+            setTimeout(() => { rej(new WatchTimeoutError()) }, timeout);
+        });
+        const watchPromise = new Promise((res: (val: void) => void) => {
+            this.waitForMap.set(endpoint, res);
+        });
+        await Promise.race([watchPromise, timeoutPromise]);
+        this.waitForMap.delete(endpoint);
+    }
+
     close() {
         if (!this.httpProxy) {
             console.warn("Cannot close because proxy was never created!")
             return;
         }
+        this.httpSever.close();
         this.httpProxy.close();
         this.httpProxy = undefined;
     }
@@ -67,21 +103,11 @@ export class Proxy {
     private setupEvents() {
         this.httpProxy.on('proxyRes', (proxyRes, req, res) => {
             const currentEndpoint = req.url;
-            const isEndpointBlocked = this.disabledEndpoints.some(endpoint => endpoint === currentEndpoint);
-            const isCompressed = proxyRes.headers["content-encoding"] === "gzip";
             const responseModifier = this.responseModifierMap.get(currentEndpoint);
             const needsDataProcessing = !!responseModifier;
-            if (!isEndpointBlocked) {
-                console.log(`Current endpoint "${currentEndpoint}" is not blocked 🟢`);
-                res.writeHead(proxyRes.statusCode, proxyRes.headers);
-                if (!needsDataProcessing) {
-                    proxyRes.pipe(res, {end: true});
-                }
-            }
-            else {
-                console.log(`Current endpoint "${currentEndpoint}" is blocked ​🔴​`);
-                res.statusCode = 503;
-                res.end("Blocked");
+            res.writeHead(proxyRes.statusCode, proxyRes.headers);
+            if (!needsDataProcessing) {
+                proxyRes.pipe(res, {end: true});
             }
             let body = [];
             proxyRes.on('data', (chunk) => { body.push(chunk); });
@@ -94,7 +120,8 @@ export class Proxy {
                 }
                 console.log(`\Response modifier found for endpoint "${currentEndpoint}"`);
                 let responseBuffer = Buffer.concat(body);
-                // un-gzip the buffer if needed
+                // Un-gzip the buffer if needed
+                const isCompressed = proxyRes.headers["content-encoding"] === "gzip";
                 if (isCompressed) {
                     responseBuffer = zlib.gunzipSync(responseBuffer);
                 }
@@ -103,14 +130,22 @@ export class Proxy {
                 if (modifiedBuffer.toString() === responseBuffer.toString()) {
                     console.warn("Response modifier made no changes!");
                 }
-                // gzip the modified buffer if needed
+                // Gzip the modified buffer if needed
                 if (isCompressed) {
                     modifiedBuffer = zlib.gzipSync(modifiedBuffer);
                 }
-                // Pass this response to the client!
+                // Pass this response to the client
                 res.end(modifiedBuffer);
             });
         });
+    }
+
+    private resolveWaitIfNeeded(endpoint: string) {
+        for (const [key, resolve] of this.waitForMap) {
+            if (endpoint.includes(key)) {
+                resolve();
+            }
+        }
     }
 
 }

--- a/src/proxy/WatchTimeoutError.ts
+++ b/src/proxy/WatchTimeoutError.ts
@@ -1,0 +1,10 @@
+export class WatchTimeoutError extends Error {
+
+    get name() {
+        return "WatchTimeoutError";
+    }
+
+    get message() {
+        return "Endpoint was not accessed before timeout.";
+    }
+}

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -1,0 +1,2 @@
+export { WatchTimeoutError } from "./WatchTimeoutError";
+export { Proxy } from "./Proxy";

--- a/src/trafficlight/NetworkProxyTrafficClient.ts
+++ b/src/trafficlight/NetworkProxyTrafficClient.ts
@@ -1,5 +1,5 @@
 import { TrafficLightClient } from "./TrafficLightClient";
-import { Proxy } from "../proxy/Proxy";
+import { Proxy, WatchTimeoutError } from "../proxy";
 
 export class NetworkProxyTrafficLightClient extends TrafficLightClient {
     private proxy: Proxy;
@@ -29,6 +29,10 @@ export class NetworkProxyTrafficLightClient extends TrafficLightClient {
             this.enableEndpoint(data.endpoint);
             return "endpointEnabled";
         });
+
+        this.on("waitUntilEndpointAccessed", async (data: Record<string, string>) => {
+            const { endpoint, timeout = "15000" } = data;
+            return await this.waitUntilEndpointAccessed(endpoint, parseInt(timeout, 10));
         });
 
         this.on("exit", async () => { this.exit(); });
@@ -70,6 +74,25 @@ export class NetworkProxyTrafficLightClient extends TrafficLightClient {
             throw new Error(`"endpoint" is not supplied with disableEndpoint action!`);
         }
         this.proxy.enableEndpoint(endpoint);
+    }
+
+    private async waitUntilEndpointAccessed(endpoint: string, timeout: number) {
+        if (!endpoint) {
+            throw new Error(`"endpoint" is not supplied with waitUntilEndpointAccessed action!`);
+        }
+        try {
+            await this.proxy.waitForEndpoint(endpoint, timeout);
+        }
+        catch (e) {
+            if (e instanceof WatchTimeoutError) {
+                console.log(`WatchTimeoutError on endpoint ${endpoint}!`);
+            }
+            else {
+                throw e;
+            }
+            return "error";
+        }
+        return "endpointAccessed";
     }
 
     private exit() {

--- a/src/trafficlight/NetworkProxyTrafficClient.ts
+++ b/src/trafficlight/NetworkProxyTrafficClient.ts
@@ -27,7 +27,8 @@ export class NetworkProxyTrafficLightClient extends TrafficLightClient {
 
         this.on("enableEndpoint", async (data: Record<string, string>) => {
             this.enableEndpoint(data.endpoint);
-            return "endpointDisabled";
+            return "endpointEnabled";
+        });
         });
 
         this.on("exit", async () => { this.exit(); });

--- a/src/trafficlight/NetworkProxyTrafficClient.ts
+++ b/src/trafficlight/NetworkProxyTrafficClient.ts
@@ -35,7 +35,7 @@ export class NetworkProxyTrafficLightClient extends TrafficLightClient {
     }
 
     async register(): Promise<void> {
-        await super._register("element-web", {
+        await super._register("network-proxy", {
             endpoint: this.proxyURL.toString(),
         });
     }

--- a/src/trafficlight/TrafficLightClient.ts
+++ b/src/trafficlight/TrafficLightClient.ts
@@ -68,7 +68,7 @@ export class TrafficLightClient {
                 throw new Error(`poll failed with ${pollResponse.status}`);
             }
             const pollData = await pollResponse.json() as PollData;
-            console.log(`* Trafficlight asked to execute action "${pollData.action}":`);
+            console.log(`* Trafficlight asked to execute action "${pollData.action}", data = ${JSON.stringify(pollData.data)}:`);
             if (pollData.action === 'exit') {
                 shouldExit = true;
             } else {


### PR DESCRIPTION
This PR:
- Adds a `waitUntilEndpointAccessed` action
- Fixes a bug where the proxy failed to block requests when `disableEndpoint` action was used