### PR TITLE
Allow LISTEN_PORT to be passed in env vars to listen on specific port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,20 @@ The proxy will again be at `http://localhost:4040`, but nodemon will reload the 
 
 There is a supported docker image at ghcr.io/vector-im/trafficlight-proxy can be used to run this proxy.
 
-You must pass `TRAFFICLIGHT_URL` and `PROXY_URL`.
+You must pass `TRAFFICLIGHT_URL` and `PROXY_URL`. You may also pass `LISTEN_PORT`.
 
-`PROXY_URL` should be set to an endpoint that the trafficlight clients can access. At present there is no way for the proxy to bind to a port different to the URL that clients would connect to; however the hostname is not used to bind the listening socket.
+`TRAFFICLIGHT_URL` should be set to a trafficlight server.
+
+`PROXY_URL` should be set to an endpoint that the trafficlight clients can access.
+
+`LISTEN_PORT` should be set to the tcp port that the proxy should bind to. If unset it will use the port from `PROXY_URL`.
+
 
 ## Changing Proxy link and trafficlight server link
 ---
 The defaults are:
 - Trafficlight server is assumed to be running at http://localhost:5000
 - Proxy will be running at http://localhost:4040
+- Proxy will listen on the port from PROXY\_URL (:4040)
 
 Change them via `TRAFFICLIGHT_URL` and `PROXY_URL` environment variables respectively.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,12 @@
 import { NetworkProxyTrafficLightClient } from "./trafficlight";
 
-const proxyURL = process.env.PROXY_URL ?? "http://localhost:4040";
+const proxyURL = new URL(process.env.PROXY_URL ?? "http://localhost:4040");
+const proxyURLPort = parseInt(proxyURL.port, 10);
+const listenPort = parseInt(process.env.LISTEN_PORT) ?? proxyURLPort;
 const trafficlightURL = process.env.trafficlightURL ?? "http://localhost:5000";
 
 async function start() {
-    const trafficLightClient = new NetworkProxyTrafficLightClient(trafficlightURL, proxyURL);
+    const trafficLightClient = new NetworkProxyTrafficLightClient(trafficlightURL, proxyURL, listenPort);
     await trafficLightClient.register();
     await trafficLightClient.start();
 }

--- a/src/trafficlight/NetworkProxyTrafficClient.ts
+++ b/src/trafficlight/NetworkProxyTrafficClient.ts
@@ -4,11 +4,13 @@ import { Proxy, WatchTimeoutError } from "../proxy";
 export class NetworkProxyTrafficLightClient extends TrafficLightClient {
     private proxy: Proxy;
     public proxyURL: URL;
+    private listenPort: number;
 
-    constructor(trafficLightServerURL: string, proxyURL: string) {
+    constructor(trafficLightServerURL: string, proxyURL: URL, listenPort: number) {
         super(trafficLightServerURL);
         this.hookActionsToMethods();
-        this.proxyURL = new URL(proxyURL);
+        this.proxyURL = proxyURL;
+        this.listenPort = listenPort;
     }
 
     private hookActionsToMethods() {
@@ -60,7 +62,6 @@ export class NetworkProxyTrafficLightClient extends TrafficLightClient {
         if (!url) {
             throw new Error(`"url" is not supplied with proxyTo action!`);
         }
-        const port = parseInt(this.proxyURL.port, 10);
         const replaceSynapseServerUrlWithProxyUrl = (data: string) => {
             console.log("Replacer running on ", url, this.proxyURL.toString());
             return data.replaceAll(url + "/", this.proxyURL.toString());
@@ -70,7 +71,7 @@ export class NetworkProxyTrafficLightClient extends TrafficLightClient {
             .addResponseModifier("/_matrix/client/v3/login", replaceSynapseServerUrlWithProxyUrl)
             .addResponseModifier("/_matrix/client/r0/login", replaceSynapseServerUrlWithProxyUrl)
             .addResponseModifier("/.well-known/matrix/client", replaceSynapseServerUrlWithProxyUrl)
-            .listen(port);
+            .listen(this.listenPort);
     }
 
     private disableEndpoint(endpoint: string) {


### PR DESCRIPTION
In situations where the external endpoint is not the same as the internal LISTEN port (eg, hosting on k8s) then being able to provide the two numbers separately is beneficial.

This allows us to eg host this proxy on a public https:// endpoint, but the port that the proxy listens on is not the https one of :443.