### PR TITLE
Rewrite server line in client/server.json file.

### DIFF
--- a/src/trafficlight/NetworkProxyTrafficClient.ts
+++ b/src/trafficlight/NetworkProxyTrafficClient.ts
@@ -69,6 +69,7 @@ export class NetworkProxyTrafficLightClient extends TrafficLightClient {
             .target(url)
             .addResponseModifier("/_matrix/client/v3/login", replaceSynapseServerUrlWithProxyUrl)
             .addResponseModifier("/_matrix/client/r0/login", replaceSynapseServerUrlWithProxyUrl)
+            .addResponseModifier("/client/server.json", replaceSynapseServerUrlWithProxyUrl)
             .addResponseModifier("/.well-known/matrix/client", replaceSynapseServerUrlWithProxyUrl)
             .listen(port);
     }


### PR DESCRIPTION
The client/server.json contains a `server` line that should be rewritten by the proxy in order for tools to login via it.